### PR TITLE
Use cubic interpolation of adf11 rates for solving ionization balances

### DIFF
--- a/colradpy/ionization_balance_class.py
+++ b/colradpy/ionization_balance_class.py
@@ -14,7 +14,8 @@ def interp_rates_adf11(logged_temp,logged_dens,temp,dens,logged_gcr):
                 for l in range(0,len(dens)):
                     interp_gcr = interp2d(logged_temp,
                                           logged_dens,
-                                          logged_gcr[i,j,:,:].transpose(1,0))
+                                          logged_gcr[i,j,:,:].transpose(1,0),
+                                          kind="cubic")
                     gcr_arr[i,j,k,l] = interp_gcr(np.log10(temp[k]),np.log10(dens[l]))
     return 10**gcr_arr
 


### PR DESCRIPTION
This switches the interpolation of adf11 rates from linear to cubic (the interpolation is still done in logarithmic space).

For adf11 rates this appears to give better results. See comparison below; the linear interpolation exhibits unphysical "bumps" in the curves that disappear when cubic interpolation is used. (technically the below comparison is technically energy balance, but ionization balance is a component of energy balance, so comparison is applicable to both).

Linear interpolation (old)
![c2+ thermalization with protium for Ti=1 0Te_old](https://github.com/johnson-c/ColRadPy/assets/18538613/81bcf706-0e59-48e2-8b53-41041c0c1938)

Cubic interpolation (new)
![c2+ thermalization with protium for Ti=1 0Te_new](https://github.com/johnson-c/ColRadPy/assets/18538613/1c7eaa70-7231-4633-bc4b-244750886e27)
