### PR TITLE
Fixed indexing bug caused by a numpy deprecation

### DIFF
--- a/colradpy/solve_matrix_exponential.py
+++ b/colradpy/solve_matrix_exponential.py
@@ -112,6 +112,7 @@ def solve_matrix_exponential_steady_state(matrix):
 
     index = list(np.ix_(*[np.arange(i) for i in eigenvals.shape]))
     index[axis] = np.abs(eigenvals).argsort(axis)
+    index = tuple(index)  # Needs to be tuple for multidimensional indexing to work
 
     if(len(np.shape(matrix)) ==4):    
         ev = eigenvectors.transpose(0,1,3,2)[index]#egienvectors sorted on eigenvals


### PR DESCRIPTION
I encountered the same issue with steady-state ionization balances as previously reported. The bug is caused by a deprecation of using non-tuple sequences for multidimensional indexing in numpy. I fixed it by simply casting the index list to a tuple before using it for indexing.

My understanding is that this should still work for older versions of numpy, since multidimensional indexing with tuples has always been supported. But probably a good idea to test this on your machine before merging.

fixes #23 