### PR TITLE
Ionization balance with charge exchange using ADF11 rates

### DIFF
--- a/colradpy/ionization_balance_class.py
+++ b/colradpy/ionization_balance_class.py
@@ -35,16 +35,18 @@ class ionization_balance():
       :param metas: List of arrays for the metastable levels in a charge state
       :type metas: list
 
-      :param temp_grid: Array of the temperatures in (eV)
+      :param temp_grid: Array of electron temperatures in (eV)
       :type temp_grid: float array
 
-      :param dens_grid: Array of the densities in (cm-3)
+      :param dens_grid: Array of electron densities in (cm-3)
       :type dens_grid: float array
 
-      :param htemp_grid: Temperature grid of thermal CX hydrogen (eV)
+      :param htemp_grid: Temperature grid of thermal CX hydrogen (eV). Must be
+       aligned with the electron temperature grid.
       :type htemp_grid: float array
 
-      :param hdens_grid: Density grid of the thermal CX hydrogen densities in (cm-3)
+      :param hdens_grid: Density grid of the thermal CX hydrogen densities in
+       (cm^-3). Must be aligned with the electron density grid.
       :type hdens_grid: float array
 
       :param soln_times: Times to calculate the solution for the time dependent solutions (s)
@@ -120,7 +122,9 @@ class ionization_balance():
         self.data['cr_data']['gcrs'] = {}
         self.data['user'] = {}
         self.data['user']['temp_grid'] = np.asarray(temp_grid) #eV
-        self.data['user']['dens_grid'] = np.asarray(dens_grid)#cm-3
+        self.data['user']['dens_grid'] = np.asarray(dens_grid) #cm^-3
+        self.data['user']['htemp_grid'] = np.asarray(htemp_grid) #eV
+        self.data['user']['hdens_grid'] = np.asarray(hdens_grid) # cm^-3
         self.data['user']['fils'] = np.asarray(fils)
         self.data['user']['init_abund'] = np.asarray(init_abund)
         self.data['user']['soln_times'] = np.asarray(soln_times)
@@ -147,9 +151,9 @@ class ionization_balance():
 
 
                 if(type(use_cx) == bool):
-                    self.data['user']['use_cx'] = np.ones(len(adf11['input_file']['metas'])-1,dtype=bool)
-                    self.data['user']['use_cx'][:] = False
-                
+                    self.data['user']['use_cx'] = np.ones(len(adf11['input_file']['metas'])-1, dtype=bool)
+                    self.data['user']['use_cx'][:] = use_cx
+
 
                 for j in range(0,len(adf11['input_file']['metas'])-1):
                     if( str(j) not in self.data['cr_data']['gcrs']):
@@ -168,20 +172,20 @@ class ionization_balance():
                         self.data['input_file']['acd'] = adf11['input_file']
                         
                     if( 'qcd' in fils[i]):
-                        self.data['cr_data']['gcrs'][str(j)]['qcd']= interp_rates_adf11(adf11['input_file']['temp_grid'],
+                        self.data['cr_data']['gcrs'][str(j)]['qcd'] = interp_rates_adf11(adf11['input_file']['temp_grid'],
                                                                                         adf11['input_file']['dens_grid'],
                                                                          temp_grid,dens_grid,adf11['input_file'][str(j)])
                         self.data['input_file']['qcd'] = adf11['input_file']
                         
                     if( 'xcd' in fils[i]):
-                        self.data['cr_data']['gcrs'][str(j)]['xcd']= interp_rates_adf11(adf11['input_file']['temp_grid'],
+                        self.data['cr_data']['gcrs'][str(j)]['xcd'] = interp_rates_adf11(adf11['input_file']['temp_grid'],
                                                                                         adf11['input_file']['dens_grid'],
                                                                          temp_grid,dens_grid,adf11['input_file'][str(j)])
                         self.data['input_file']['xcd'] = adf11['input_file']                               
                     if( 'ccd' in fils[i]):        
-                        self.data['cr_data']['gcrs'][str(j)]['ccd']= interp_rates_adf11(adf11['input_file']['temp_grid'],
+                        self.data['cr_data']['gcrs'][str(j)]['ccd'] = interp_rates_adf11(adf11['input_file']['temp_grid'],
                                                                                         adf11['input_file']['dens_grid'],
-                                                                         temp_grid,dens_grid,adf11['input_file'][str(j)])
+                                                                         htemp_grid,hdens_grid,adf11['input_file'][str(j)])
                         self.data['input_file']['ccd'] = adf11['input_file']                        
                         
                     if('qcd' not in self.data['cr_data']['gcrs'][str(j)]):

--- a/colradpy/read_adf11.py
+++ b/colradpy/read_adf11.py
@@ -25,8 +25,8 @@ def read_adf11(fil):
     adf11['input_file']['charge_max'] = int(tmp[4])
 
     f.readline() #reading '-------------'
-    if('r' in re.split('_', os.path.split(fil)[-1])[0]):
-        
+    file_type = re.split('_', os.path.split(fil)[-1])[0]
+    if('r' in file_type):
         adf11['input_file']['metas'] = np.array(list(   #metastables
                        map(int,re.findall('(\d+)',f.readline()))))
         f.readline() #reading '---------------'
@@ -49,32 +49,32 @@ def read_adf11(fil):
         num_stages = len(adf11['input_file']['metas'])
     for i in range(0,num_stages):
         adf11['input_file'][str(i)] = {}
-        if( 'scd' in fil or 'acd' in fil):
+        if any(x in file_type for x in ['scd', 'acd', 'ccd']):
             adf11['input_file'][str(i)] = np.zeros((adf11['input_file']['metas'][i],
                                                      adf11['input_file']['metas'][i+1],
                                              len(adf11['input_file']['temp_grid']),
                                              len(adf11['input_file']['dens_grid'])))
-        if( 'qcd' in fil ):
+        if( 'qcd' in file_type ):
             adf11['input_file'][str(i)] = np.zeros((adf11['input_file']['metas'][i],
                                                      adf11['input_file']['metas'][i],
                                              len(adf11['input_file']['temp_grid']),
                                              len(adf11['input_file']['dens_grid'])))
-        if('xcd' in fil):
+        if('xcd' in file_type):
             adf11['input_file'][str(i)] = np.zeros((adf11['input_file']['metas'][i+1],
                                                      adf11['input_file']['metas'][i+1],
                                              len(adf11['input_file']['temp_grid']),
                                              len(adf11['input_file']['dens_grid'])))
-        if('plt' in fil):
+        if('plt' in file_type):
             adf11['input_file'][str(i)] = np.zeros((adf11['input_file']['metas'][i],
                                                      adf11['input_file']['metas'][i],
                                              len(adf11['input_file']['temp_grid']),
                                              len(adf11['input_file']['dens_grid'])))
-        if('prb' in fil):
+        if('prb' in file_type):
             adf11['input_file'][str(i)] = np.zeros((adf11['input_file']['metas'][i],
                                                      adf11['input_file']['metas'][i],
                                              len(adf11['input_file']['temp_grid']),
                                              len(adf11['input_file']['dens_grid'])))
-            
+
     #Reading the GCR value portion
     gcr_line = f.readline()
     ii = 0


### PR DESCRIPTION
Currently, it is not possible to run an ionization balance with charge exchange included when ADF11 rates are being used; you have to use ADF04 rates. The reason for this appeared to be that reading CX rates from ADF11 ccd files was not implemented in `read_adf11`. I implemented this and now it is possible to run the ionization balance calculation.

I am using carbon as a test case. Here is what the steady-state ionization balance looks like for n_e = 1e19 m^-3 with no CX:
![Figure_1](https://github.com/johnson-c/ColRadPy/assets/18538613/193d3ac4-2e45-4ef6-b9e6-9018513fcd40)

And here is what it looks like with CX included for a neutral hydrogen density and temperature of 5e17 m^-3 and 5 eV, respectively:
![Figure_2](https://github.com/johnson-c/ColRadPy/assets/18538613/8ff8a25d-03e0-4c59-a184-844ee2b6e9be)

Ideally, these results would be compared against an ionization balance where the CX rates are determined from ADF04 files. However, I don't know how to run ionization balances with ADF04 rates. That being said they look qualitatively similar to the results from previous ionization balances with CX included (e.g. Adam McLean's 2021 PSI contribution).

