### PR TITLE
Bugfix for reading ADF04 files

### DIFF
--- a/colradpy/read_adf04_py3_class.py
+++ b/colradpy/read_adf04_py3_class.py
@@ -119,7 +119,7 @@ def read_adf04(fil):
                 
 
                 if( tmp[tmp_inds[config_stop]].count(')') > 1):
-                    w.append(float(re.split('[(]',tmp[tmp_inds[config_stop]])[2][0:4]))
+                    w.append(float(re.split('[()]',tmp[tmp_inds[config_stop]])[3]))
                     offset = -1
                 else:
                     w.append(float(re.split('[)]',re.split('[(]',tmp[tmp_inds[config_stop+1]])[0])[0]))


### PR DESCRIPTION
I encountered a bug reading an ADF04 file for neutral tungsten where the J numbers of the levels were not being parsed correctly. The cause appears to be that ADF04 files are inconsistent about putting a space before the J number. For example, the be1+ file has the ground state as `(2)0( 0.5)` (space before 0.5), while the w0 file I'm using has the ground state as `(5)2(0.0)` (no space before 0.0).

I fixed this by changing the regular expression format for processing the level information. This works for the w0 file I'm using and the be1+ file used by the example, but I haven't tested this extensively. 